### PR TITLE
fix "Passing individual values" issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,29 +168,35 @@ module.exports = {
 
 ## <a name="passing-individual-values"></a> Passing individual values
 
+> If you are getting all your `htmlWebpackPlugin` instances generated within a loop, and you want to get indivisual passing values for each `.ejs` template as variables, you can try this :D. (This method is using webapck loader inline mechanic to load every `ejs` file instead, you can also set html-loader/template-ejs-Loader options for each `.ejs` file.)
+
 `webpack.config.js`
 
 ```javascript
+const { htmlWebpackPluginTemplateCustomizer }  = require('template-ejs-loader')
+...
 module.exports = {
-  ~~~
+  ...
 
   plugins: [
     new HtmlWebpackPlugin({
       filename: 'index.html',
-      template: `!${require.resolve('html-loader')}??ruleSet[1].rules[0].use[0]!${path.resolve(
-        __dirname,
-        '../lib/index.js'
-      )}?${queryString.stringify({
-        // Use the query as an option to pass to the loader
-        root: './src/ejs',
-        data: JSON.stringify({
-          foo: 'bar',
-        }),
-      })}!${path.resolve(__dirname, './src/ejs/index.ejs')}`,
+      template: htmlWebpackPluginTemplateCustomizer({
+        htmlLoaderOption:{
+          ... // set individual html-loader option here
+        },
+        templateEjsLoaderOption:{
+          root:'' // set individual template-ejs-loader option here
+          data:{
+            foo:'test' // you can have indivisual data injection for each .ejs file, too. 
+          }
+        },
+        templatePath:'./src/index.ejs' // ejs template path 
+      }),
     }),
   ]
 
-  ~~~
+  ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ module.exports = {
 
 ## <a name="passing-individual-values"></a> Passing individual values
 
-> If you are getting all your `htmlWebpackPlugin` instances generated within a loop, and you want to get indivisual passing values for each `.ejs` template as variables, you can try this :D. (This method is using webapck loader inline mechanic to load every `ejs` file instead, you can also set html-loader/template-ejs-Loader options for each `.ejs` file.)
+> If you are getting all your `htmlWebpackPlugin` instances generated within a loop, and you want to get indivisual passing values for each `.ejs` template as variables, you can try this. (This method is using webapck loader inline mechanic to load every `ejs` file instead, you can also set html-loader/template-ejs-Loader options for each `.ejs` file.)
 
 `webpack.config.js`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 import { readFileSync } from 'fs'
 import { resolve, dirname } from 'path'
-
 import { compile, Options, Data } from 'ejs'
 import { LoaderContext } from 'webpack'
 
-import type { AdditionalData, SourceMap,htmlWebpackPluginTemplateCustomizerConfig } from './types'
+import type { AdditionalData, SourceMap } from './types'
 type EjsLoaderContext = LoaderContext<Options & { data?: Data | string }>
 
 const getIncludeEjsDependencies = (
@@ -101,7 +100,15 @@ const obj2URLQueryString = (config?:{[prop: string]: any })=>{
   return new URLSearchParams(optionArr).toString()
 }
 
-export type { SourceMap, AdditionalData,htmlWebpackPluginTemplateCustomizerConfig }
+export type htmlWebpackPluginTemplateCustomizerConfig = {
+  htmlLoaderOption? :{
+    [key: string]: any
+  },
+  templateEjsLoaderOption?:Options
+  templatePath?:string
+}
+
+export type { SourceMap, AdditionalData }
 
 export function htmlWebpackPluginTemplateCustomizer(config:htmlWebpackPluginTemplateCustomizerConfig){
   const htmlLoader = `${require.resolve("html-loader")}` // get html-loader entry path

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ export type htmlWebpackPluginTemplateCustomizerConfig = {
   htmlLoaderOption? :{
     [key: string]: any
   },
-  templateEjsLoaderOption?:Options
+  templateEjsLoaderOption?: Options & { data?: Data | string }
   templatePath?:string
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { resolve, dirname } from 'path'
 import { compile, Options, Data } from 'ejs'
 import { LoaderContext } from 'webpack'
 
-import type { AdditionalData, SourceMap } from './types'
+import type { AdditionalData, SourceMap,htmlWebpackPluginTemplateCustomizerConfig } from './types'
 type EjsLoaderContext = LoaderContext<Options & { data?: Data | string }>
 
 const getIncludeEjsDependencies = (
@@ -88,8 +88,38 @@ const resolveRequirePaths = async (context: EjsLoaderContext, content: string) =
 
   return resultContent
 }
+// Since Node.js had marked the querystring as legacy API in version 14.x, and recommended using URLSearchParams,
+// we should migrate from "querystring" to "URLSearchParams" if we want to get URL query string here.
+// check this: https://www.linkedin.com/pulse/how-migrate-from-querystring-urlsearchparams-nodejs-vladim%C3%ADr-gorej?trk=articles_directory
+const obj2URLQueryString = (config?:{[prop: string]: any })=>{
+  if(!config)return''
+  let optionArr:string[][] = []
+  Object.keys(config).forEach((key)=>{
+    const optionItem = [key,JSON.stringify(config[key])]
+    optionArr.push(optionItem)
+  })
+  return new URLSearchParams(optionArr).toString()
+}
 
-export type { SourceMap, AdditionalData }
+export type { SourceMap, AdditionalData,htmlWebpackPluginTemplateCustomizerConfig }
+
+export function htmlWebpackPluginTemplateCustomizer(config:htmlWebpackPluginTemplateCustomizerConfig){
+  const htmlLoader = `${require.resolve("html-loader")}` // get html-loader entry path
+  const templateEjsLoader = `${require.resolve("template-ejs-loader")}` // get template-ejs-loader entry path
+
+  let htmlLoaderOption = `${obj2URLQueryString(config.htmlLoaderOption)}` // get html-loader option
+  let templateEjsLoaderOption = `${obj2URLQueryString(config.templateEjsLoaderOption)}` // get template-ejs-loader option
+  // Check if option string is empty; (And if it's not, prepend a questionmark '?');
+  // This usage is about webpack loader inline, you can check the spec here : https://webpack.js.org/concepts/loaders/#inline
+  if(htmlLoaderOption){
+    htmlLoaderOption = `?${htmlLoaderOption}`;
+  }
+  if(templateEjsLoaderOption){
+    templateEjsLoaderOption = `?${templateEjsLoaderOption}`;
+  }
+  // combile loaders/loader options/templatePath then generate customized template name
+  return `!${htmlLoader}${htmlLoaderOption}!${templateEjsLoader}${templateEjsLoaderOption}!${config.templatePath}`
+}
 
 export default async function ejsLoader(
   this: EjsLoaderContext,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,16 +12,3 @@ export type AdditionalData = {
   [index: string]: any
   webpackAST: object
 }
-
-export type htmlWebpackPluginTemplateCustomizerConfig = {
-  htmlLoaderOption? :{
-    [key: string]: any
-  },
-  templateEjsLoaderOption?:{
-    root?:string,
-    data:{
-      [key: string]: any
-    }
-  },
-  templatePath?:string
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,3 +12,16 @@ export type AdditionalData = {
   [index: string]: any
   webpackAST: object
 }
+
+export type htmlWebpackPluginTemplateCustomizerConfig = {
+  htmlLoaderOption? :{
+    [key: string]: any
+  },
+  templateEjsLoaderOption?:{
+    root?:string,
+    data:{
+      [key: string]: any
+    }
+  },
+  templatePath?:string
+}


### PR DESCRIPTION
Hey man, I got another pull request for you, and I also helped fix your README, too.
It is about the issue "Passing individual values",  I found that the old method you mentioned in README using `querystring` is not working(seems to be something wrong about your entry path)

And since `Node.js` had marked the `querystring` as legacy API in version 14.x, and recommended using URLSearchParams, I think we should give the old method an upgrade .

I am still using webpack loader inline for this problem,  but I change the old method for a little bit (You can check it).

If you have any problem, feel free to contact me using twitter : D

Cheers 👍 

fix #11 