### PR TITLE
Fix htmlWebpackPluginTemplateCustomizer option type problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## <a name="features"></a>Features
 
 - webpack5 support
-- Import `.js`,`.json` and `node modules` using `require
+- Import `.js`,`.json` and `node modules` using `require`
 - All files can be passed values.
 
 ## <a name="installation"></a> Instalation
@@ -168,7 +168,9 @@ module.exports = {
 
 ## <a name="passing-individual-values"></a> Passing individual values
 
-If you are getting all your `htmlWebpackPlugin` instances generated within a loop, and you want to get indivisual passing values for each `.ejs` template as variables, you can try this. (This method is using webapck loader inline mechanic to load every `ejs` file instead, you can also set html-loader/template-ejs-Loader options for each `.ejs` file.)
+If you are getting all your `htmlWebpackPlugin` instances generated within a loop, and you want to get indivisual passing values for each `.ejs` template as variables, you can try this. (This method is using `webapck loader inline` mechanic to load every `ejs` file instead, you can also set html-loader/template-ejs-Loader options for each `.ejs` file.)
+
+Unfortunaly, because `webapck loader inline` does not support loader option in which type is function, so basicly the option `preprocessor` of `html-loader` is **NOT** supported here, better try another way if you need to do interpolate things, for example: using `templateEjsLoaderOption.data` to set individual inject value.
 
 `webpack.config.js`
 
@@ -182,16 +184,19 @@ module.exports = {
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: htmlWebpackPluginTemplateCustomizer({
-        htmlLoaderOption:{
-          ... // set individual html-loader option here
-        },
-        templateEjsLoaderOption:{
-          root:'' // set individual template-ejs-loader option here
-          data:{
-            foo:'test' // you can have indivisual data injection for each .ejs file, too. 
-          }
-        },
+
         templatePath:'./src/index.ejs' // ejs template path 
+
+        htmlLoaderOption:{
+          // you can set individual html-loader option here.
+          // but preprocessor option is not supported.
+        },
+        templateEjsLoaderOption:{ // set individual template-ejs-loader option here
+          root:'', // this is for example, if not needed, just feel free to delete.
+          data:{ // example, too.
+            foo:'test' // btw, you can have indivisual data injection for each .ejs file using data option
+          }
+        }
       }),
     }),
   ]


### PR DESCRIPTION
# Description

I found that the problem  was caused by `query string`. 

When we parsed the full loader option object to `query string`, it actually parsed every value to `string,` which means there will be no `Boolean` type value.

check this: https://stackoverflow.com/questions/6461668/boolean-in-a-uri-query

So here my solution is parsing options to `JSON` using `JSON.stringify`, instead of parsing to `query string`( `JSON` is also an acceptable type here for `webpack loader inline`).

check this: https://webpack.js.org/concepts/loaders/#inline

But unfortunately, both of these two way do NOT support option value in which type is function, which means  the `html-loader` option : `preprocessor`  is not supported here (I not only mentioned this in README.md, but also made a colorful console.log inside `index.ts` in case someone doesn't read the doc)

Any suggestion will be appreciated, I am wondering if  there will be a better way to fix this issue.


Fixes #19  (issue)

## Type of change

Please delete options that are not relevant.

- [v ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ v] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ v] My code follows the style guidelines of this project
- [v ] I have performed a self-review of my own code
- [ v] I have commented my code, particularly in hard-to-understand areas
- [v ] I have made corresponding changes to the documentation
- [v ] My changes generate no new warnings
