### PR TITLE
fix: originalIncluderで名前解決を行うときにDependencyに追加されない不具合

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 import { resolve, sep } from 'path'
 
-import { compile, Options, Data } from 'ejs'
+import { compile, Data, IncluderResult, Options } from 'ejs'
 import { LoaderContext } from 'webpack'
 
 import type { AdditionalData, SourceMap } from './types'
@@ -99,14 +99,12 @@ export default async function ejsLoader(
 
   const originalIncluder = loaderOptions.includer ?? null
   const customizeIncluder = (originalPath: string, parsedPath: string) => {
-    this.addDependency(parsedPath)
+    let includerResult: IncluderResult = { filename: parsedPath }
     if (originalIncluder !== null) {
-      return originalIncluder(originalPath, parsedPath)
-    } else {
-      return {
-        filename: parsedPath,
-      }
+      includerResult = originalIncluder(originalPath, parsedPath)
     }
+    this.addDependency(includerResult.filename || parsedPath)
+    return includerResult
   }
 
   loaderOptions.includer = customizeIncluder


### PR DESCRIPTION
# Description
webpack.config.jsのオプションでfilenameを書き換えて返却した場合にエラーが起きる。
addDependencyがoriginalIncluderの名前解決結果を行うより先に、parsedPathによって実行されているため

# Reproduce
https://github.com/kajikentaro/webpack-ejs-html/releases/tag/PR-template-ejs-loader
上記をクローンし、`npm i`, `npm run dev`を順に実行する
該当コード
```
          {

            loader: "template-ejs-loader",
            options: {
              includer: (originalPath, parsedPath) => {
                let filename = "";
                if (/^\./.test(originalPath)) {
                  // includeでパスが'.'から始まる場合
                  filename = parsedPath;
                } else if (/^\//.test(originalPath)) {
                  // includeでパスが'/'から始まる場合
                  filename = path.resolve(__dirname, "src", "." + originalPath);
                } else {
                  console.log(originalPath, parsedPath);
                  filename = path.resolve(__dirname, "src", originalPath);
                }

                if (filename && fs.existsSync(filename)) {
                  return { filename };
                }
                // ファイルが存在しない場合
                throw new Error("Not Found: could not resolve " + originalPath);
              }
            }
          }
```
エラー
```
  Child HtmlWebpackCompiler compiled with 1 warning

WARNING in ./src/sub/index.ejs
Invalid dependencies have been reported by plugins or loaders for this module. All reported dependencies need to be absolute paths.
Invalid dependencies may lead to broken watching and caching.
As best effort we try to convert all invalid values to absolute paths and converting globs into context dependencies, but this is deprecated behavior.
Loaders: Pass absolute paths to this.addDependency (existing files), this.addMissingDependency (not existing files), and this.addContextDependency (directories).
Plugins: Pass absolute paths to fileDependencies (existing files), missingDependencies (not existing files), and contextDependencies (directories).
Globs: They are not supported. Pass absolute path to the directory as context dependencies.
The following invalid values have been reported:
 * undefined
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?
ローカル環境でエラーが消えることを確認

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
